### PR TITLE
feat: implement 'working-directory' argument

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import * as core from '@actions/core';
 import {getCLI} from './cli';
 import * as options from './options';
+import * as process from 'process';
 
 (async () => {
   try {
@@ -23,9 +24,15 @@ import * as options from './options';
       false
     );
     const version = await options.getVersion();
+    const workingDirectory = options.getWorkingDirectory();
 
     core.debug(`Version is ${version}`);
     await cli.new(version, {projects});
+
+    const currentWorkingDirectory = process.cwd();
+    if (workingDirectory !== null && workingDirectory.length > 0) {
+      process.chdir(workingDirectory);
+    }
 
     if (setCommitsOption !== 'skip') {
       core.debug(`Setting commits with option '${setCommitsOption}'`);
@@ -64,6 +71,10 @@ import * as options from './options';
     core.debug(`Finalizing the release`);
     if (shouldFinalize) {
       await cli.finalize(version);
+    }
+
+    if (workingDirectory !== null && workingDirectory.length > 0) {
+      process.chdir(currentWorkingDirectory);
     }
 
     core.debug(`Done`);

--- a/src/options.ts
+++ b/src/options.ts
@@ -165,3 +165,7 @@ export const getProjects = (): string[] => {
 export const getUrlPrefixOption = (): string => {
   return core.getInput('url_prefix');
 };
+
+export const getWorkingDirectory = (): string => {
+  return core.getInput('working_directory');
+};


### PR DESCRIPTION
When running the action-release Github Action, occasionally one might need to perform auto-detection of associated commits in a directory other than the job's working directory, such as in the case where an action performs multiple checkouts. As Github Actions do not, by default, support the ability to run an action in any directory other than the job's working directory, this change implements an argument for specifying which directory to gather sentry release information from.